### PR TITLE
[feat] 카카오 OAuth Provider 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+    // open feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/pmu/domain/user/auth/KakaoAccessToken.java
+++ b/src/main/java/org/pmu/domain/user/auth/KakaoAccessToken.java
@@ -1,0 +1,20 @@
+package org.pmu.domain.user.auth;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class KakaoAccessToken {
+    private static final String TOKEN_TYPE = "Bearer ";
+    private String accessToken;
+
+    public static KakaoAccessToken createKakaoAccessToken(String accessToken) {
+        return new KakaoAccessToken(accessToken);
+    }
+
+    public String getAccessTokenWithTokenType() {
+        return TOKEN_TYPE + accessToken;
+    }
+}

--- a/src/main/java/org/pmu/domain/user/auth/KakaoAccessTokenInfo.java
+++ b/src/main/java/org/pmu/domain/user/auth/KakaoAccessTokenInfo.java
@@ -1,0 +1,11 @@
+package org.pmu.domain.user.auth;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KakaoAccessTokenInfo {
+    private Long id;
+}

--- a/src/main/java/org/pmu/domain/user/auth/KakaoFeignClient.java
+++ b/src/main/java/org/pmu/domain/user/auth/KakaoFeignClient.java
@@ -1,0 +1,12 @@
+package org.pmu.domain.user.auth;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakao-feign-client", url = "https://kapi.kakao.com/")
+public interface KakaoFeignClient {
+    @GetMapping("v1/user/access_token_info")
+    KakaoAccessTokenInfo getKakaoAccessTokenInfo(@RequestHeader("Authorization") String accessToken);
+}
+

--- a/src/main/java/org/pmu/domain/user/auth/KakaoOAuthProvider.java
+++ b/src/main/java/org/pmu/domain/user/auth/KakaoOAuthProvider.java
@@ -1,0 +1,31 @@
+package org.pmu.domain.user.auth;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pmu.global.error.ErrorCode;
+import org.pmu.global.error.UnauthorizedException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KakaoOAuthProvider {
+    private final KakaoFeignClient kakaoFeignClient;
+
+    public String getKakaoPlatformId(String accessToken) {
+        KakaoAccessToken kakaoAccessToken = KakaoAccessToken.createKakaoAccessToken(accessToken);
+        String accessTokenWithTokenType = kakaoAccessToken.getAccessTokenWithTokenType();
+        KakaoAccessTokenInfo kakaoAccessTokenInfo = getKakaoAccessTokenInfo(accessTokenWithTokenType);
+        return String.valueOf(kakaoAccessTokenInfo.getId());
+    }
+
+    private KakaoAccessTokenInfo getKakaoAccessTokenInfo(String accessTokenWithTokenType) {
+        try {
+            return kakaoFeignClient.getKakaoAccessTokenInfo(accessTokenWithTokenType);
+        } catch (FeignException e) {
+            log.error("Feign Exception: ", e);
+            throw new UnauthorizedException(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
+        }
+    }
+}

--- a/src/main/java/org/pmu/global/config/FeignClientConfig.java
+++ b/src/main/java/org/pmu/global/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package org.pmu.global.config;
+
+import org.pmu.PmuApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@EnableFeignClients(basePackageClasses = PmuApplication.class)
+@Configuration
+public class FeignClientConfig {
+}


### PR DESCRIPTION
## Related Issue 🍃
close #8 

## Description 🌴
- 카카오 서버와 통신을 하기 위한 카카오 Feign Client를 구현하였습니다.
- 카카오 OAuth Provider를 구현하였습니다.
