### PR TITLE
로그인 & 회원 가입 카카오톡 프로필 조회 비즈니스 로직 추가

### DIFF
--- a/src/main/java/org/pmu/domain/user/auth/KakaoFeignClient.java
+++ b/src/main/java/org/pmu/domain/user/auth/KakaoFeignClient.java
@@ -8,5 +8,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface KakaoFeignClient {
     @GetMapping("v1/user/access_token_info")
     KakaoAccessTokenInfo getKakaoAccessTokenInfo(@RequestHeader("Authorization") String accessToken);
-}
 
+    @GetMapping("v1/api/talk/profile")
+    KakaoUserProfile getKakaoUserProfile(@RequestHeader("Authorization") String accessToken);
+}

--- a/src/main/java/org/pmu/domain/user/auth/KakaoOAuthProvider.java
+++ b/src/main/java/org/pmu/domain/user/auth/KakaoOAuthProvider.java
@@ -7,6 +7,8 @@ import org.pmu.global.error.ErrorCode;
 import org.pmu.global.error.UnauthorizedException;
 import org.springframework.stereotype.Component;
 
+import static org.pmu.domain.user.auth.KakaoAccessToken.createKakaoAccessToken;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -14,15 +16,31 @@ public class KakaoOAuthProvider {
     private final KakaoFeignClient kakaoFeignClient;
 
     public String getKakaoPlatformId(String accessToken) {
-        KakaoAccessToken kakaoAccessToken = KakaoAccessToken.createKakaoAccessToken(accessToken);
+        KakaoAccessToken kakaoAccessToken = createKakaoAccessToken(accessToken);
         String accessTokenWithTokenType = kakaoAccessToken.getAccessTokenWithTokenType();
         KakaoAccessTokenInfo kakaoAccessTokenInfo = getKakaoAccessTokenInfo(accessTokenWithTokenType);
         return String.valueOf(kakaoAccessTokenInfo.getId());
     }
 
+    public String getKakaoUserProfileImageUrl(String accessToken) {
+        KakaoAccessToken kakaoAccessToken = createKakaoAccessToken(accessToken);
+        String accessTokenWithTokenType = kakaoAccessToken.getAccessTokenWithTokenType();
+        KakaoUserProfile kakaoUserProfile = getKakaoUserProfile(accessTokenWithTokenType);
+        return kakaoUserProfile.getProfileImageURL();
+    }
+
     private KakaoAccessTokenInfo getKakaoAccessTokenInfo(String accessTokenWithTokenType) {
         try {
             return kakaoFeignClient.getKakaoAccessTokenInfo(accessTokenWithTokenType);
+        } catch (FeignException e) {
+            log.error("Feign Exception: ", e);
+            throw new UnauthorizedException(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
+        }
+    }
+
+    private KakaoUserProfile getKakaoUserProfile(String accessTokenWithTokenType) {
+        try {
+            return kakaoFeignClient.getKakaoUserProfile(accessTokenWithTokenType);
         } catch (FeignException e) {
             log.error("Feign Exception: ", e);
             throw new UnauthorizedException(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN);

--- a/src/main/java/org/pmu/domain/user/auth/KakaoUserProfile.java
+++ b/src/main/java/org/pmu/domain/user/auth/KakaoUserProfile.java
@@ -1,0 +1,13 @@
+package org.pmu.domain.user.auth;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KakaoUserProfile {
+    private String nickName;
+    private String profileImageURL;
+    private String thumbnailURL;
+}

--- a/src/main/java/org/pmu/domain/user/domain/User.java
+++ b/src/main/java/org/pmu/domain/user/domain/User.java
@@ -26,6 +26,10 @@ public class User {
                 .build();
     }
 
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }


### PR DESCRIPTION
## Related Issue 🍃
close #24 

## Description 🌴
- Feign Client를 활용하여 카카오 서버에서 제공하는 카카오톡 프로필 조회 API 통신 기능을 추가하였습니다.
- 로그인 & 회원 가입 시 카카오톡 프로필 조회를 하도록 비즈니스 로직을 변경하였습니다.
