### PR TITLE
[feat] 음악 테이블 엔티티 매핑

### DIFF
--- a/src/main/java/org/pmu/domain/music/domain/Music.java
+++ b/src/main/java/org/pmu/domain/music/domain/Music.java
@@ -1,0 +1,31 @@
+package org.pmu.domain.music.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.pmu.domain.user.domain.User;
+import org.pmu.global.common.BaseTimeEntity;
+
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Music extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "music_id")
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @Column(updatable = false)
+    private String coverImageUrl;
+    @Column(updatable = false)
+    private String genre;
+    @Column(updatable = false)
+    private String title;
+    @Column(updatable = false)
+    private String singer;
+    @Column(updatable = false)
+    private String youtubeUrl;
+}

--- a/src/main/java/org/pmu/domain/user/domain/User.java
+++ b/src/main/java/org/pmu/domain/user/domain/User.java
@@ -4,21 +4,33 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.pmu.domain.music.domain.Music;
+import org.pmu.global.common.BaseTimeEntity;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+import java.util.ArrayList;
+import java.util.List;
+
 @Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @DynamicInsert
 @DynamicUpdate
 @Table(name = "users")
 @Entity
-public class User {
+public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
+    @Builder.Default
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
+    private List<Music> musics = new ArrayList<>();
+    @Column(updatable = false)
     private String platformId;
+    @Column(updatable = false)
     private String profileImageUrl;
+    @Column(updatable = false)
     private String nickname;
     private String refreshToken;
 


### PR DESCRIPTION
## Related Issue 🍃
close #33 

## Description 🌴
- 음악 엔티티를 구현하였습니다.
- 사용자 엔티티에서 누락된 애노테이션을 추가하였습니다.
- 사용자 엔티티와 음악 엔티티의 연관관계를 설정하였습니다.
